### PR TITLE
Allow single UID selection in user menu

### DIFF
--- a/src/greeter.rs
+++ b/src/greeter.rs
@@ -544,8 +544,8 @@ impl Greeter {
 
       tracing::info!("min/max UIDs are {}/{}", min_uid, max_uid);
 
-      if min_uid >= max_uid {
-        return Err("Minimum UID ({min_uid}) must be less than maximum UID ({max_uid})".into());
+      if min_uid > max_uid {
+        return Err("Minimum UID ({min_uid}) must be less than or equal to maximum UID ({max_uid})".into());
       }
 
       self.users = Menu {


### PR DESCRIPTION
Currently, the `--user-menu-min-uid` and `--user-menu-max-uid` options require that `min-uid < max-uid`, which makes it impossible to restrict the selection menu to a single UID. This is problematic in setups where only one user should appear in the menu but adjacent UIDs also belong to valid users (e.g., showing only UID `1000` when both `999` and `1001` are present).

**This PR relaxes the check to allow `min-uid == max-uid`,** enabling users to set both options to the same value and present only one UID in the user selection menu.

#### Example usage:

```
tuigreet ... --user-menu --user-menu-min-uid 1000 --user-menu-max-uid 1000
```

This will only show the user with UID `1000` in the selection menu.

---

### Indirectly addresses #94

This change also indirectly addresses [PR #94](https://github.com/apognu/tuigreet/pull/94) (“Allow passing a username directly”). Instead of a username, users can now specify:

```
tuigreet ... --user-menu --user-menu-min-uid $(id -u <username>) --user-menu-max-uid $(id -u <username>)
```

This achieves similar functionality by showing only the specified user's UID.