### PR TITLE
fix(config): do not default *sessions_dirs attrs

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,11 +477,14 @@ rows = 52
 
 ### Sessions
 
-The available sessions are fetched from `desktop` files in
-`/usr/share/xsessions` and `/usr/share/wayland-sessions`. If you want to provide
-custom directories, you can set the `--sessions` arguments with a
-colon-separated list of directories for `tuigreet` to fetch session definitions
-some other place.
+The available sessions are discovered by iterating over all paths present in the
+`$XDG_DATA_DIR` environmental variable, then looking for `.desktop` files in
+`xsessions/` and `wayland-sessions/` subdirectories. If you want to search for
+sessions in custom directories, you can set the `--sessions` arguments with a
+colon-separated list of directories.
+
+On most Linux distributions, `.desktop` files are stored in the `/usr/share/xsessions`
+and `/usr/share/wayland-sessions` directories respectively.
 
 #### Desktop environments
 
@@ -514,16 +517,14 @@ Exec=/path/to/my/wrapper.sh
 
 #### Common wrappers
 
-Two options allows you to automatically wrap run commands around sessions
-started from desktop files, depending on whether they come
-`/usr/share/wayland-sessions` or `/usr/share/xsessions`: `--sessions-wrapper`
-and `--xsessions-wrapper`. With this, you can prepend another command on front
-of the sessions you run to set up the required environment to run these kinds of
-sessions.
+Two options allow you to automatically wrap run commands around sessions started
+from desktop files, depending on whether they come from `wayland-sessions/` or
+`xsessions/`: `--sessions-wrapper` and `--xsessions-wrapper`. With this, you can
+prepend another command in front of the sessions you run to set up the required
+environment to run these kinds of sessions.
 
-By default, unless you change it, all X11 sessions (those picked up from
-`/usr/share/xsessions`) are prepended with `startx /usr/bin/env`, so the X11
-server is started properly.
+By default, all X11 sessions (those picked up from `/xsessions`) are prepended
+with `startx /usr/bin/env`, so the X11 server is started properly.
 
 ### Power management
 

--- a/crates/tuigreet-config/src/parser.rs
+++ b/crates/tuigreet-config/src/parser.rs
@@ -983,16 +983,6 @@ impl Config {
       );
     }
 
-    // Warn about empty session directories
-    if self.session.sessions_dirs.is_empty()
-      && self.session.xsessions_dirs.is_empty()
-    {
-      warnings.push(
-        "No session directories configured, users may not be able to select \
-         sessions"
-          .to_string(),
-      );
-    }
 
     // Warn about potentially invalid time formats
     if let Some(ref format) = self.display.time_format

--- a/crates/tuigreet-config/src/schema.rs
+++ b/crates/tuigreet-config/src/schema.rs
@@ -166,11 +166,11 @@ pub struct SessionConfig {
   pub command: Option<String>,
 
   /// Directories containing Wayland session files
-  #[serde(default = "default_sessions_dirs")]
+  #[serde(default)]
   pub sessions_dirs: Vec<String>,
 
   /// Directories containing X11 session files
-  #[serde(default = "default_xsessions_dirs")]
+  #[serde(default)]
   pub xsessions_dirs: Vec<String>,
 
   /// Wrapper command for non-X11 sessions
@@ -190,8 +190,8 @@ impl Default for SessionConfig {
   fn default() -> Self {
     Self {
       command:          None,
-      sessions_dirs:    default_sessions_dirs(),
-      xsessions_dirs:   default_xsessions_dirs(),
+      sessions_dirs:    vec![],
+      xsessions_dirs:   vec![],
       session_wrapper:  None,
       xsession_wrapper: default_xsession_wrapper(),
       environments:     Vec::new(),
@@ -649,14 +649,6 @@ const fn default_show_title() -> bool {
 
 fn default_log_file() -> String {
   "/tmp/tuigreet.log".to_string()
-}
-
-fn default_sessions_dirs() -> Vec<String> {
-  vec!["/usr/share/wayland-sessions".to_string()]
-}
-
-fn default_xsessions_dirs() -> Vec<String> {
-  vec!["/usr/share/xsessions".to_string()]
 }
 
 fn default_xsession_wrapper() -> Option<String> {

--- a/crates/tuigreet/src/greeter.rs
+++ b/crates/tuigreet/src/greeter.rs
@@ -1574,13 +1574,10 @@ mod test {
     greeter.apply_config(&replacement);
 
     assert!(matches!(greeter.session_source, SessionSource::None));
-    assert_eq!(greeter.session_paths.len(), 2);
-    assert!(
-      greeter
-        .session_paths
-        .iter()
-        .any(|(path, _)| path == "/second")
-    );
+    assert_eq!(greeter.session_paths, [(
+      std::path::PathBuf::from("/second"),
+      SessionType::Wayland
+    )]);
     assert!(greeter.session_wrapper.is_none());
     assert!(!greeter.user_menu);
     assert!(greeter.users.options.is_empty());
@@ -1710,29 +1707,27 @@ mod test {
 
   #[tokio::test]
   async fn test_session_paths_are_deduplicated_after_config_overlay() {
+    let sess_dir = "/usr/share/wayland-sessions";
+
     let mut greeter = Greeter::default();
 
     assert!(
       greeter
-        .parse_options(&["--sessions", "/usr/share/wayland-sessions"])
+        .parse_options(&["--sessions", sess_dir])
         .await
         .is_ok()
     );
 
-    let config = Config::default();
+    // CLI options are merged into the configuration before it is applied, so
+    // the same directory can appear several times.
+    let mut config = Config::default();
+    config.session.sessions_dirs = vec![sess_dir.to_string(); 2];
     greeter.apply_config(&config);
 
-    assert_eq!(
-      greeter
-        .session_paths
-        .iter()
-        .filter(|(path, session_type)| {
-          path == &std::path::PathBuf::from("/usr/share/wayland-sessions")
-            && session_type == &SessionType::Wayland
-        })
-        .count(),
-      1
-    );
+    assert_eq!(greeter.session_paths, [(
+      std::path::PathBuf::from(sess_dir),
+      SessionType::Wayland
+    )]);
   }
 
   #[tokio::test]


### PR DESCRIPTION
Fixes #217

`$XDG_DATA_DIRS` already contains `/usr/share` on all standard Linux distributions, so the default is redundant and [shadows the call to `default_session_paths`][1].

[1]: https://github.com/tuigreet/tuigreet/blob/0.11.0/crates/tuigreet/src/info.rs#L290-L292