### PR TITLE
fix(ui): force full screen redraw when ESC is pressed to clear TTY pollution

### DIFF
--- a/crates/tuigreet/src/greeter.rs
+++ b/crates/tuigreet/src/greeter.rs
@@ -174,6 +174,11 @@ pub struct Greeter {
   pub done:    bool,
   // Should we exit?
   pub exit:    Option<AuthStatus>,
+
+  // When true, the next render frame will display a Clear widget to force
+  // redraw of the terminal (useful after external TTY writes pollute the
+  // screen, e.g. from systemd boot logs).
+  pub needs_clear: bool,
 }
 
 impl Default for Greeter {
@@ -236,6 +241,7 @@ impl Default for Greeter {
       working:                    false,
       done:                       false,
       exit:                       None,
+      needs_clear:                false,
     }
   }
 }

--- a/crates/tuigreet/src/integration/menus.rs
+++ b/crates/tuigreet/src/integration/menus.rs
@@ -276,9 +276,11 @@ async fn users_menu() {
       assert!(runner.output().await.contains("Password:"));
 
       runner.send_key(KeyCode::Esc).await;
+      runner.wait_for_render().await;
       runner.send_key(KeyCode::Enter).await;
       runner.send_key(KeyCode::Up).await;
       runner.send_key(KeyCode::Enter).await;
+      runner.wait_for_render().await;
       runner.wait_for_render().await;
 
       assert!(runner.output().await.contains("Username: Antoine POPINEAU"));

--- a/crates/tuigreet/src/integration/remember.rs
+++ b/crates/tuigreet/src/integration/remember.rs
@@ -32,6 +32,7 @@ async fn remember_username() {
       runner.wait_until_buffer_contains("Password:").await;
       runner.send_key(KeyCode::Esc).await;
       runner.wait_for_render().await;
+      runner.wait_for_render().await;
 
       assert!(runner.output().await.contains("Username:       "));
       assert!(!runner.output().await.contains("Password:"));

--- a/crates/tuigreet/src/keyboard.rs
+++ b/crates/tuigreet/src/keyboard.rs
@@ -7,6 +7,7 @@ use tuigreet_types::Mode;
 
 use crate::{
   Greeter,
+  event::Event,
   info::{
     delete_last_command,
     delete_last_session,
@@ -82,6 +83,8 @@ pub async fn handle(
     KeyEvent {
       code: KeyCode::Esc, ..
     } => {
+      greeter.needs_clear = true;
+
       match greeter.mode {
         Mode::Command => {
           greeter.mode = greeter.previous_mode;
@@ -97,6 +100,10 @@ pub async fn handle(
           Ipc::cancel(&mut greeter).await;
           greeter.reset(false).await;
         },
+      }
+
+      if let Some(ref sender) = greeter.events {
+        let _ = sender.send(Event::Render).await;
       }
     },
 

--- a/crates/tuigreet/src/ui/mod.rs
+++ b/crates/tuigreet/src/ui/mod.rs
@@ -81,6 +81,23 @@ where
   let mut greeter = greeter.write().await;
   let hide_cursor = should_hide_cursor(&greeter);
 
+  if greeter.needs_clear {
+    greeter.needs_clear = false;
+    terminal.draw(|f| {
+      let area = f.area();
+      let buf = f.buffer_mut();
+      for y in area.top()..area.bottom() {
+        for x in area.left()..area.right() {
+          if let Some(cell) = buf.cell_mut((x, y)) {
+            cell.set_char('█');
+            cell.set_fg(tui::style::Color::DarkGray);
+          }
+        }
+      }
+    })?;
+    return Ok(());
+  }
+
   terminal.draw(|f| {
     let area = f.area();
     if let Some(anim) = greeter.animation.as_mut() {


### PR DESCRIPTION
When systemd boot logs or other processes write to the TTY, they can overwrite the login form. Since ratatui uses buffer diffing to avoid redrawing unchanged cells, these external writes are not cleared.

This commit adds a force-redraw mechanism triggered by ESC:
- When ESC is pressed, fill the screen with █ characters (dark gray) before the next render, forcing ratatui's diff to see real changes
- This ensures all cells, including background/padding, are redrawn
- The login form properly clears and redraws on top

Fixes #68

<img width="1920" height="1080" alt="tuigreet-esc-clear" src="https://github.com/user-attachments/assets/459b40e7-f7f8-43a5-9118-b7fffe6935de" />
